### PR TITLE
feat: adding support for arguments in `cancel_cmd`

### DIFF
--- a/snakemake_executor_plugin_cluster_generic/__init__.py
+++ b/snakemake_executor_plugin_cluster_generic/__init__.py
@@ -299,7 +299,7 @@ class Executor(RemoteExecutor):
                     if self.sidecar_vars:
                         env["SNAKEMAKE_CLUSTER_SIDECAR_VARS"] = self.sidecar_vars
                     subprocess.check_call(
-                        [self.workflow.executor_settings.cancel_cmd] + chunk,
+                        self.workflow.executor_settings.cancel_cmd.split(" ") + chunk,
                         shell=False,
                         timeout=cancel_timeout,
                         env=env,


### PR DESCRIPTION
My home-made CLI to interface snakemake to our batch system requires arguments to the `kill` functions. 

Currently, arguments are not supported because `cancel_cmd` is passed as a single token to `subprocess.check_call`.

I suggest to split `cancel_cmd` into multiple tokens, instead.