### PR TITLE
fix: remove trailing whitespace from submitcmd

### DIFF
--- a/snakemake_executor_plugin_cluster_generic/__init__.py
+++ b/snakemake_executor_plugin_cluster_generic/__init__.py
@@ -223,7 +223,7 @@ class Executor(RemoteExecutor):
                                 "workflow execution, "
                                 "have a closer look.).".format(
                                     self.workflow.executor_settings.status_cmd,
-                                    ",".join(self.status_cmd_kills),
+                                    ",".join(map(str, self.status_cmd_kills)),
                                 )
                             )
                             self.status_cmd_kills.clear()

--- a/snakemake_executor_plugin_cluster_generic/__init__.py
+++ b/snakemake_executor_plugin_cluster_generic/__init__.py
@@ -151,7 +151,7 @@ class Executor(RemoteExecutor):
             ext_jobid = (
                 subprocess.check_output(
                     '{submitcmd} "{jobscript}"'.format(
-                        submitcmd=submitcmd, jobscript=jobscript
+                        submitcmd=submitcmd.rstrip(), jobscript=jobscript
                     ),
                     shell=True,
                     env=env,

--- a/snakemake_executor_plugin_cluster_generic/__init__.py
+++ b/snakemake_executor_plugin_cluster_generic/__init__.py
@@ -151,7 +151,7 @@ class Executor(RemoteExecutor):
             ext_jobid = (
                 subprocess.check_output(
                     '{submitcmd} "{jobscript}"'.format(
-                        submitcmd=submitcmd.rstrip(), jobscript=jobscript
+                        submitcmd=submitcmd.rstrip(), jobscript=shlex.quote(jobscript)
                     ),
                     shell=True,
                     env=env,
@@ -201,7 +201,7 @@ class Executor(RemoteExecutor):
                     ret = subprocess.check_output(
                         "{statuscmd} '{jobid}'".format(
                             jobid=job_info.external_jobid,
-                            statuscmd=self.workflow.executor_settings.status_cmd,
+                            statuscmd=self.workflow.executor_settings.status_cmd.rstrip(),
                         ),
                         shell=True,
                         env=env,
@@ -299,7 +299,7 @@ class Executor(RemoteExecutor):
                     if self.sidecar_vars:
                         env["SNAKEMAKE_CLUSTER_SIDECAR_VARS"] = self.sidecar_vars
                     subprocess.check_call(
-                        [self.workflow.executor_settings.cancel_cmd] + chunk,
+                        [self.workflow.executor_settings.cancel_cmd.rstrip()] + chunk,
                         shell=False,
                         timeout=cancel_timeout,
                         env=env,
@@ -369,7 +369,7 @@ class Executor(RemoteExecutor):
 
         self.logger.info("Launch sidecar process and read first output line.")
         process = subprocess.Popen(
-            self.workflow.executor_settings.sidecar_cmd,
+            self.workflow.executor_settings.sidecar_cmd.rstrip(),
             stdout=subprocess.PIPE,
             shell=False,
             encoding="utf-8",

--- a/snakemake_executor_plugin_cluster_generic/__init__.py
+++ b/snakemake_executor_plugin_cluster_generic/__init__.py
@@ -150,7 +150,7 @@ class Executor(RemoteExecutor):
 
             ext_jobid = (
                 subprocess.check_output(
-                    '{submitcmd} "{jobscript}"'.format(
+                    '{submitcmd} {jobscript}'.format(
                         submitcmd=submitcmd.rstrip(), jobscript=shlex.quote(jobscript)
                     ),
                     shell=True,
@@ -199,8 +199,8 @@ class Executor(RemoteExecutor):
                     if self.sidecar_vars:
                         env["SNAKEMAKE_CLUSTER_SIDECAR_VARS"] = self.sidecar_vars
                     ret = subprocess.check_output(
-                        "{statuscmd} '{jobid}'".format(
-                            jobid=job_info.external_jobid,
+                        "{statuscmd} {jobid}".format(
+                            jobid=shlex.quote(job_info.external_jobid),
                             statuscmd=self.workflow.executor_settings.status_cmd.rstrip(),
                         ),
                         shell=True,
@@ -299,7 +299,7 @@ class Executor(RemoteExecutor):
                     if self.sidecar_vars:
                         env["SNAKEMAKE_CLUSTER_SIDECAR_VARS"] = self.sidecar_vars
                     subprocess.check_call(
-                        [self.workflow.executor_settings.cancel_cmd.rstrip()] + chunk,
+                        shlex.split(self.workflow.executor_settings.cancel_cmd) + chunk,
                         shell=False,
                         timeout=cancel_timeout,
                         env=env,
@@ -369,7 +369,7 @@ class Executor(RemoteExecutor):
 
         self.logger.info("Launch sidecar process and read first output line.")
         process = subprocess.Popen(
-            self.workflow.executor_settings.sidecar_cmd.rstrip(),
+            shlex.split(self.workflow.executor_settings.sidecar_cmd),
             stdout=subprocess.PIPE,
             shell=False,
             encoding="utf-8",


### PR DESCRIPTION
This should fix https://github.com/snakemake/snakemake-executor-plugin-cluster-generic/issues/22: trailing newlines in the `submitcmd` (provided by the user as `cluster-generic-submit-cmd`) cause the job submission to fail silently as the trailing newline terminates the command in `subprocess.run(..., shell=True)` before the job script.

https://github.com/snakemake/snakemake-executor-plugin-cluster-generic/blob/ce5fc8278e97313fd911f5d91b4e95954ab64469/snakemake_executor_plugin_cluster_generic/__init__.py#L152-L158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Trimmed trailing whitespace from scheduler commands to improve reliability of submissions, status checks, sidecar launches, and cancellations.
  - Applied shell-escaping to submitted scripts and job identifiers to reduce intermittent submission/status/cancellation failures.
  - Improved invocation of cancellation and sidecar commands to avoid quoting and formatting issues with multi-part commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->