### PR TITLE
docs: Add documentation with example usage

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -1,0 +1,11 @@
+### Example setup
+
+The cluster generic plugin enables access to workflow variables (such as `rule`, `resources`, or `threads`) within the strings used to define cluster generic plugin arguments.
+This makes it possible to create custom configurations for running workflows on various cluster systems that support a submission command accepting the path to a job script. The following example Snakemake profile (see [Profiles](https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles)) shows this for a custom SLURM execution configuration setup. Submitting jobs with this setup would result in having the rule name of the current job contained in the SLURM job name.
+
+```yaml
+executor: cluster-generic
+cluster-generic-submit-cmd: sbatch --cpus-per-task {threads} --mem={resources.mem_mb} --job-name=smk-{rule} --parsable
+cluster-generic-cancel-cmd: scancel
+```
+

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,2 @@
+The cluster generic plugin allows submitting jobs to cluster systems that provide a submission command that accepts the path to a job script.
+


### PR DESCRIPTION
Add initial documentation with an example on how to use the plugin.

Closes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Example setup" section showing how to configure the cluster-generic plugin with workflow variables embedded in cluster command arguments for custom cluster behavior.
  * Included a profile example demonstrating job submission and naming using rule-derived information for SLURM-style clusters.
  * Expanded the introduction to briefly describe the cluster-generic plugin’s role in submitting jobs to cluster systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->